### PR TITLE
make nanoid package a dependency instead of a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,8 +2081,7 @@
     "nanoid": {
       "version": "3.1.22",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
-      "dev": true
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "node build.js --all"
   },
   "dependencies": {
+    "nanoid": "^3.1.22",
     "open": "^7.4.2",
     "yargs": "^16.2.0"
   },
@@ -53,7 +54,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "nanoid": "^3.1.22",
     "npm-run-all": "^4.1.5",
     "preact": "^10.5.13",
     "prettier": "^2.2.1",


### PR DESCRIPTION
after I installed `esbuild-visualizer` I tried to run it and got this error:

```
$ yarn build:analyze
yarn run v1.22.11
$ esbuild-visualizer --metadata ./meta.json
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'nanoid/non-secure'
Require stack:
- FILEPATH/node_modules/esbuild-visualizer/dist/plugin/module-mapper.js
- FILEPATH/node_modules/esbuild-visualizer/dist/plugin/index.js
- FILEPATH/node_modules/esbuild-visualizer/dist/bin/cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (FILEPATH/node_modules/esbuild-visualizer/dist/plugin/module-mapper.js:4:22)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'FILEPATH/node_modules/esbuild-visualizer/dist/plugin/module-mapper.js',
    'FILEPATH/node_modules/esbuild-visualizer/dist/plugin/index.js',
    'FILEPATH/node_modules/esbuild-visualizer/dist/bin/cli.js'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I believe the `nanoid` package needs to be a _dependency_ instead of a _devDependency_ because the [main bin](https://github.com/btd/esbuild-visualizer/blob/master/package.json#L6) file [imports `visualizer`](https://github.com/btd/esbuild-visualizer/blob/master/bin/cli.ts#L13) from `plugin/index` which [imports `ModuleMapper`](https://github.com/btd/esbuild-visualizer/blob/master/plugin/index.ts#L4) from `plugin/module-mapper` which [imports `customAlphabet`](https://github.com/btd/esbuild-visualizer/blob/master/plugin/module-mapper.ts#L1) from `nanoid/non-secure`