### PR TITLE
Fix: ensure tooltip is in window

### DIFF
--- a/src/network/tooltip.tsx
+++ b/src/network/tooltip.tsx
@@ -50,12 +50,12 @@ export const Tooltip: FunctionalComponent<TooltipProps> = ({ node, visible }) =>
 
     if (pos.left + boundingRect.width > window.innerWidth) {
       // Shifting horizontally
-      pos.left = window.innerWidth - boundingRect.width;
+      pos.left = Math.max(window.innerWidth - boundingRect.width, 0);
     }
 
     if (pos.top + boundingRect.height > window.innerHeight) {
       // Flipping vertically
-      pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+      pos.top = Math.max(mouseCoords.y - Tooltip_marginY - boundingRect.height, 0);
     }
 
     setStyle(pos);

--- a/src/style/_base.scss
+++ b/src/style/_base.scss
@@ -60,8 +60,6 @@ main {
 
   padding: 5px;
 
-  white-space: nowrap;
-
   font-size: 0.875rem;
 
   background-color: var(--background-color);

--- a/src/treemap/tooltip.tsx
+++ b/src/treemap/tooltip.tsx
@@ -130,12 +130,12 @@ export const Tooltip: FunctionalComponent<TooltipProps> = ({
 
     if (pos.left + boundingRect.width > window.innerWidth) {
       // Shifting horizontally
-      pos.left = window.innerWidth - boundingRect.width;
+      pos.left = Math.max(window.innerWidth - boundingRect.width, 0);
     }
 
     if (pos.top + boundingRect.height > window.innerHeight) {
       // Flipping vertically
-      pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+      pos.top = Math.max(mouseCoords.y - Tooltip_marginY - boundingRect.height, 0);
     }
 
     setStyle(pos);


### PR DESCRIPTION
fix #8 

| Before             |  After |
|:-------------------------:|:-------------------------:|
| <img width="1440" alt="capture before" src="https://github.com/btd/esbuild-visualizer/assets/33599414/e4ea34c7-e036-49f8-9977-0ba3eadeb23d"> | <img width="1440" alt="capture after" src="https://github.com/btd/esbuild-visualizer/assets/33599414/3e50e091-3718-4f7b-b1e1-6804c8dfd632"> |